### PR TITLE
Fix File Upload Accept Prop Handling

### DIFF
--- a/client/src/components/ui/file-upload.tsx
+++ b/client/src/components/ui/file-upload.tsx
@@ -2,13 +2,30 @@ import React, { useCallback } from 'react';
 import { useDropzone } from 'react-dropzone';
 import { cn } from '@/lib/utils';
 
+type AcceptProp = string | string[] | undefined;
+
 interface FileUploadProps {
   onDrop: (files: File[]) => void;
-  accept?: string;
+  accept?: AcceptProp;
   multiple?: boolean;
   maxSize?: number;
   className?: string;
   children?: React.ReactNode;
+}
+
+function buildAccept(accept?: AcceptProp): Record<string, string[]> | undefined {
+  if (!accept) return undefined;
+
+  const types = Array.isArray(accept)
+    ? accept
+    : accept.split(',').map((s) => s.trim()).filter(Boolean);
+
+  if (types.length === 0) return undefined;
+
+  return types.reduce<Record<string, string[]>>((acc, mime) => {
+    acc[mime] = [];
+    return acc;
+  }, {});
 }
 
 export function FileUpload({
@@ -25,7 +42,7 @@ export function FileUpload({
 
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
     onDrop: handleDrop,
-    accept: accept ? { [accept]: [] } : undefined,
+    accept: buildAccept(accept),
     multiple,
     maxSize
   });


### PR DESCRIPTION
This PR modifies the `FileUpload` component to handle the `accept` prop more effectively, which addresses the issue causing the media page to go blank. The `accept` prop now supports both string and array formats to specify MIME types. A new helper function, `buildAccept`, has been introduced to properly convert the `accept` value into the format expected by the `useDropzone` hook. This change ensures that valid file types can be dropped without causing the page to crash.

---

> This pull request was co-created with Cosine Genie

Original Task: [devijewellers-1/5814ajtujcuo](https://cosine.sh/cl4v0r61en9n/devijewellers-1/task/5814ajtujcuo)
Author: devijewellerssatara
