### PR TITLE
Fix import syntax in admin-dashboard.tsx

### DIFF
--- a/client/src/pages/admin-dashboard.tsx
+++ b/client/src/pages/admin-dashboard.tsx
@@ -6,13 +6,7 @@ import { z } from "zod";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 import {
   Form,


### PR DESCRIPTION
This pull request modifies the import statement in the `admin-dashboard.tsx` file to use a more compact and valid syntax. The previous multiline import caused syntax errors during the Vite pre-transform stage, leading to application startup issues. The updated import statement now correctly imports `Select`, `SelectContent`, `SelectItem`, `SelectTrigger`, and `SelectValue` in a single line.

---

> This pull request was co-created with Cosine Genie

Original Task: [devijewellers-1/hnhbwumman83](https://cosine.sh/cl4v0r61en9n/devijewellers-1/task/hnhbwumman83)
Author: devijewellerssatara
