### PR TITLE
Hide Navigation Tabs on TV Display Page

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -17,7 +17,9 @@ function Router() {
     <div className="min-h-screen bg-gold-50">
       <Navigation />
       <Switch>
+        {/* Make TV Display available at /tv and keep / for backward compatibility */}
         <Route path="/" component={TVDisplay} />
+        <Route path="/tv" component={TVDisplay} />
         <Route path="/mobile" component={MobileControl} />
         <Route path="/admin" component={AdminDashboard} />
         <Route path="/media" component={MediaManager} />

--- a/client/src/components/navigation.tsx
+++ b/client/src/components/navigation.tsx
@@ -18,6 +18,11 @@ const navItems: NavItem[] = [
 export function Navigation() {
   const [location] = useLocation();
 
+  // Hide navigation tabs on the TV Display page
+  if (location === "/" || location.startsWith("/tv")) {
+    return null;
+  }
+
   return (
     <div className="bg-white shadow-lg sticky top-0 z-50">
       <div className="max-w-7xl mx-auto">


### PR DESCRIPTION
This pull request modifies the routing and navigation system to hide the admin dashboard, mobile control, media manager, and promo manager tabs on the TV display page. The TV display is now accessible via the new link: http://localhost:3000/tv, while maintaining backward compatibility with the original route at '/'. This enhances the user experience by simplifying the interface when viewing the TV display.

---

> This pull request was co-created with Cosine Genie

Original Task: [devijewellers-1/v5ri6gvzh5l9](https://cosine.sh/cl4v0r61en9n/devijewellers-1/task/v5ri6gvzh5l9)
Author: devijewellerssatara
