### PR TITLE
Ensure Images Maintain Aspect Ratio with Padding

### DIFF
--- a/client/src/pages/media-manager.tsx
+++ b/client/src/pages/media-manager.tsx
@@ -230,21 +230,25 @@ export default function MediaManager() {
                   <div key={item.id} className="border rounded-lg overflow-hidden bg-white shadow-sm">
                     <div className="relative">
                       {item.media_type === 'image' ? (
-                        <img 
-                          src={item.file_url || ""} 
-                          alt={item.name}
-                          className="w-full h-48 object-cover"
-                          onError={(e) => {
-                            e.currentTarget.src = '/placeholder-image.jpg';
-                          }}
-                        />
+                        <div className="w-full aspect-video bg-black">
+                          <img 
+                            src={item.file_url || ""} 
+                            alt={item.name}
+                            className="w-full h-full object-contain"
+                            onError={(e) => {
+                              (e.currentTarget as HTMLImageElement).src = '/placeholder-image.jpg';
+                            }}
+                          />
+                        </div>
                       ) : (
-                        <video 
-                          src={item.file_url || ""}
-                          className="w-full h-48 object-cover"
-                          controls
-                          preload="metadata"
-                        />
+                        <div className="w-full aspect-video bg-black">
+                          <video 
+                            src={item.file_url || ""}
+                            className="w-full h-full object-contain"
+                            controls
+                            preload="metadata"
+                          />
+                        </div>
                       )}
                       <div className="absolute top-2 right-2">
                         <Button

--- a/client/src/pages/promo-manager.tsx
+++ b/client/src/pages/promo-manager.tsx
@@ -235,11 +235,11 @@ export default function PromoManager() {
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-8">
           {promoImages.map((item) => (
             <Card key={item.id} className={`overflow-hidden ${item.is_active ? 'border-2 border-purple-500' : 'border border-gray-200 opacity-75'}`}>
-              <div className="relative aspect-video bg-gray-100">
+              <div className="relative aspect-video bg-black">
                 <img 
                   src={item.image_url || ""} 
                   alt={item.name}
-                  className="w-full h-full object-cover"
+                  className="w-full h-full object-contain"
                   data-testid={`promo-image-${item.id}`}
                 />
                 
@@ -352,13 +352,13 @@ export default function PromoManager() {
           <CardContent className="p-6">
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
               {/* Preview Window */}
-              <div className="relative bg-gray-100 rounded-lg overflow-hidden aspect-video">
+              <div className="relative bg-black rounded-lg overflow-hidden aspect-video">
                 {activePromos.length > 0 ? (
                   <>
                     <img 
                       src={activePromos[currentPreviewIndex]?.image_url || ""} 
                       alt="Slideshow preview" 
-                      className="w-full h-full object-cover"
+                      className="w-full h-full object-contain"
                       data-testid="slideshow-preview-image"
                     />
                     

--- a/client/src/pages/tv-display.tsx
+++ b/client/src/pages/tv-display.tsx
@@ -326,7 +326,7 @@ export default function TVDisplay() {
                               key={currentPromo.id}
                               src={currentPromo.image_url || ""}
                               alt={currentPromo.name || "Promotional Image"}
-                              className="w-full h-full object-cover"
+                              className="w-full h-full object-contain"
                               initial="initial"
                               animate="animate"
                               exit="exit"


### PR DESCRIPTION
This PR modifies the image display in the Media Manager, Promo Manager, and TV Display components to ensure that images maintain their original aspect ratio without being cropped. Instead of using 'object-cover', which can crop images, the 'object-contain' class is used to fit the images within a 16:9 ratio padding, preventing any loss of image content. This change enhances the visual presentation of images across the application.

---

> This pull request was co-created with Cosine Genie

Original Task: [devijewellers-1/qhzmj6hc910y](https://cosine.sh/cl4v0r61en9n/devijewellers-1/task/qhzmj6hc910y)
Author: devijewellerssatara
