### PR TITLE
Update font size for SALE and PURCHASE rates

### DIFF
--- a/client/src/pages/tv-display.tsx
+++ b/client/src/pages/tv-display.tsx
@@ -239,11 +239,11 @@ export default function TVDisplay() {
                     </div>
                     <div className="grid grid-cols-2 gap-2 md:gap-4">
                       <div className="text-center p-2 md:p-4 bg-blue-50 rounded-lg border border-blue-200">
-                        <p className="text-xs md:text-sm text-blue-600 font-semibold mb-1">SALE RATE</p>
+                        <p className="text-xs md:text-4xl text-blue-600 font-semibold mb-1">SALE RATE</p>
                         <p className={`${rateFontSize} font-bold text-blue-800`}>₹{currentRates.gold_24k_sale}</p>
                       </div>
                       <div className="text-center p-2 md:p-4 bg-blue-50 rounded-lg border border-blue-200">
-                        <p className="text-xs md:text-sm text-blue-600 font-semibold mb-1">PURCHASE RATE</p>
+                        <p className="text-xs md:text-4xl text-blue-600 font-semibold mb-1">PURCHASE RATE</p>
                         <p className={`${rateFontSize} font-bold text-blue-800`}>₹{currentRates.gold_24k_purchase}</p>
                       </div>
                     </div>
@@ -259,11 +259,11 @@ export default function TVDisplay() {
                     </div>
                     <div className="grid grid-cols-2 gap-2 md:gap-4">
                       <div className="text-center p-2 md:p-4 bg-blue-50 rounded-lg border border-blue-200">
-                        <p className="text-xs md:text-sm text-blue-600 font-semibold mb-1">SALE RATE</p>
+                        <p className="text-xs md:text-4xl text-blue-600 font-semibold mb-1">SALE RATE</p>
                         <p className={`${rateFontSize} font-bold text-blue-800`}>₹{currentRates.gold_22k_sale}</p>
                       </div>
                       <div className="text-center p-2 md:p-4 bg-blue-50 rounded-lg border border-blue-200">
-                        <p className="text-xs md:text-sm text-blue-600 font-semibold mb-1">PURCHASE RATE</p>
+                        <p className="text-xs md:text-4xl text-blue-600 font-semibold mb-1">PURCHASE RATE</p>
                         <p className={`${rateFontSize} font-bold text-blue-800`}>₹{currentRates.gold_22k_purchase}</p>
                       </div>
                     </div>
@@ -279,11 +279,11 @@ export default function TVDisplay() {
                     </div>
                     <div className="grid grid-cols-2 gap-2 md:gap-4">
                       <div className="text-center p-2 md:p-4 bg-blue-50 rounded-lg border border-blue-200">
-                        <p className="text-xs md:text-sm text-blue-600 font-semibold mb-1">SALE RATE</p>
+                        <p className="text-xs md:text-4xl text-blue-600 font-semibold mb-1">SALE RATE</p>
                         <p className={`${rateFontSize} font-bold text-blue-800`}>₹{currentRates.gold_18k_sale}</p>
                       </div>
                       <div className="text-center p-2 md:p-4 bg-blue-50 rounded-lg border border-blue-200">
-                        <p className="text-xs md:text-sm text-blue-600 font-semibold mb-1">PURCHASE RATE</p>
+                        <p className="text-xs md:text-4xl text-blue-600 font-semibold mb-1">PURCHASE RATE</p>
                         <p className={`${rateFontSize} font-bold text-blue-800`}>₹{currentRates.gold_18k_purchase}</p>
                       </div>
                     </div>
@@ -305,11 +305,11 @@ export default function TVDisplay() {
                       </div>
                       <div className="grid grid-cols-2 gap-2 md:gap-4">
                         <div className="text-center p-2 md:p-4 bg-blue-50 rounded-lg border border-blue-200">
-                          <p className="text-xs md:text-sm text-blue-600 font-semibold mb-1">SALE RATE</p>
+                          <p className="text-xs md:text-4xl text-blue-600 font-semibold mb-1">SALE RATE</p>
                           <p className={`${rateFontSize} font-bold text-blue-800`}>₹{currentRates.silver_per_kg_sale}</p>
                         </div>
                         <div className="text-center p-2 md:p-4 bg-blue-50 rounded-lg border border-blue-200">
-                          <p className="text-xs md:text-sm text-blue-600 font-semibold mb-1">PURCHASE RATE</p>
+                          <p className="text-xs md:text-4xl text-blue-600 font-semibold mb-1">PURCHASE RATE</p>
                           <p className={`${rateFontSize} font-bold text-blue-800`}>₹{currentRates.silver_per_kg_purchase}</p>
                         </div>
                       </div>


### PR DESCRIPTION
This pull request modifies the font size for the SALE and PURCHASE rate labels in the TV display component. Specifically, it changes the medium screen size class from 'md:text-sm' to 'md:text-4xl'. This adjustment enhances the visibility and aesthetics of these key metrics when displayed on larger screens, providing a better user experience.

---

> This pull request was co-created with Cosine Genie

Original Task: [devijewellers-1/4awh27l23uw8](https://cosine.sh/cl4v0r61en9n/devijewellers-1/task/4awh27l23uw8)
Author: devijewellerssatara
