### PR TITLE
storage: enforce 50-row cap per table and overwrite oldest entries

### DIFF
--- a/server/storage.ts
+++ b/server/storage.ts
@@ -143,19 +143,7 @@ async createDisplaySettings(settings: InsertDisplaySettings): Promise<DisplaySet
 
   async createMediaItem(item: InsertMediaItem): Promise<MediaItem> {
     const result = await db.insert(mediaItems).values(item).returning();
-    const created = result[0];
-
-    // Enforce cap for media items
-    const toDelete = await db
-      .select({ id: mediaItems.id })
-      .from(mediaItems)
-      .orderBy(desc(mediaItems.created_date))
-      .offset(ROW_CAP);
-    if (toDelete.length) {
-      await db.delete(mediaItems).where(inArray(mediaItems.id, toDelete.map(r => r.id)));
-    }
-
-    return created;
+    return result[0];
   }
 
   async updateMediaItem(id: number, item: Partial<InsertMediaItem>): Promise<MediaItem | undefined> {
@@ -185,19 +173,7 @@ async createDisplaySettings(settings: InsertDisplaySettings): Promise<DisplaySet
 
   async createPromoImage(image: InsertPromoImage): Promise<PromoImage> {
     const result = await db.insert(promoImages).values(image).returning();
-    const created = result[0];
-
-    // Enforce cap for promo images
-    const toDelete = await db
-      .select({ id: promoImages.id })
-      .from(promoImages)
-      .orderBy(desc(promoImages.created_date))
-      .offset(ROW_CAP);
-    if (toDelete.length) {
-      await db.delete(promoImages).where(inArray(promoImages.id, toDelete.map(r => r.id)));
-    }
-
-    return created;
+    return result[0];
   }
 
   async updatePromoImage(id: number, image: Partial<InsertPromoImage>): Promise<PromoImage | undefined> {

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -17,7 +17,7 @@ import {
   type BannerSettings,
   type InsertBannerSettings
 } from "@shared/schema";
-import { eq, desc, asc } from "drizzle-orm";
+import { eq, desc, asc, inArray } from "drizzle-orm";
 import { mkdirSync } from "fs";
 import { join } from "path";
 
@@ -34,6 +34,9 @@ if (!connectionString) {
 // Create PostgreSQL client
 const client = postgres(connectionString);
 const db = drizzle(client);
+
+// Hard cap for rows to retain per table
+const ROW_CAP = 50;
 
 export interface IStorage {
   // Gold Rates
@@ -79,7 +82,19 @@ export class PostgresStorage implements IStorage {
     await db.update(goldRates).set({ is_active: false });
     
     const result = await db.insert(goldRates).values(rate).returning();
-    return result[0];
+    const created = result[0];
+
+    // Enforce cap: keep most recent ROW_CAP by created_date
+    const toDelete = await db
+      .select({ id: goldRates.id })
+      .from(goldRates)
+      .orderBy(desc(goldRates.created_date))
+      .offset(ROW_CAP);
+    if (toDelete.length) {
+      await db.delete(goldRates).where(inArray(goldRates.id, toDelete.map(r => r.id)));
+    }
+
+    return created;
   }
 
   async updateGoldRate(id: number, rate: Partial<InsertGoldRate>): Promise<GoldRate | undefined> {
@@ -128,7 +143,19 @@ async createDisplaySettings(settings: InsertDisplaySettings): Promise<DisplaySet
 
   async createMediaItem(item: InsertMediaItem): Promise<MediaItem> {
     const result = await db.insert(mediaItems).values(item).returning();
-    return result[0];
+    const created = result[0];
+
+    // Enforce cap for media items
+    const toDelete = await db
+      .select({ id: mediaItems.id })
+      .from(mediaItems)
+      .orderBy(desc(mediaItems.created_date))
+      .offset(ROW_CAP);
+    if (toDelete.length) {
+      await db.delete(mediaItems).where(inArray(mediaItems.id, toDelete.map(r => r.id)));
+    }
+
+    return created;
   }
 
   async updateMediaItem(id: number, item: Partial<InsertMediaItem>): Promise<MediaItem | undefined> {
@@ -158,7 +185,19 @@ async createDisplaySettings(settings: InsertDisplaySettings): Promise<DisplaySet
 
   async createPromoImage(image: InsertPromoImage): Promise<PromoImage> {
     const result = await db.insert(promoImages).values(image).returning();
-    return result[0];
+    const created = result[0];
+
+    // Enforce cap for promo images
+    const toDelete = await db
+      .select({ id: promoImages.id })
+      .from(promoImages)
+      .orderBy(desc(promoImages.created_date))
+      .offset(ROW_CAP);
+    if (toDelete.length) {
+      await db.delete(promoImages).where(inArray(promoImages.id, toDelete.map(r => r.id)));
+    }
+
+    return created;
   }
 
   async updatePromoImage(id: number, image: Partial<InsertPromoImage>): Promise<PromoImage | undefined> {


### PR DESCRIPTION
This PR adds a hard cap of 50 rows per table in server/storage.ts and deletes the oldest records when the cap is exceeded. Changes include:

- Add inArray import from drizzle-orm and a ROW_CAP = 50 constant.
- After inserts in createGoldRate, createMediaItem and createPromoImage, select IDs ordered by created_date (most recent first) and offset by ROW_CAP to find excess rows, then delete those oldest rows by ID.
- Returns the created record as before.

Effect: keeps only the most recent 50 entries for goldRates, mediaItems and promoImages, overwriting oldest data automatically to limit storage growth.

---

> This pull request was co-created with Cosine Genie

Original Task: [devijewellers-1/49cgcbsdmn2j](https://cosine.sh/cl4v0r61en9n/devijewellers-1/task/49cgcbsdmn2j)
Author: devijewellerssatara
